### PR TITLE
fix(deps): Removing redundant dependabot job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,17 +16,6 @@ updates:
       prefix: "chore"
       include: "scope"
 
-  - package-ecosystem: "gradle"
-    directory: "app/" # Location of the app build.gradle file
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    reviewers:
-      - "Jacobbrewer1"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Describe your changes

As the global gradle config reads the app gradle config, we do not need the apps job.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] For new code, I have added tests that prove my fix is effective or that my feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have implemented monitoring for my changes if applicable.
